### PR TITLE
fix incorrect time notation.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -14,15 +14,13 @@ function numberToString(n) {
  * @return {String} The offset.
  */
 function getCLFOffset(date) {
-	const offset	= date.getTimezoneOffset().toString();
-	const op		= offset[0] === '-' ? '-' : '+';
-	let number		= offset.replace(op, '');
-
-	while (number.length < 4) {
-		number = `0${number}`;
-	}
-
-	return `${op}${number}`;
+	const tzoffset    = date.getTimezoneOffset();
+	const abstzoffset = Math.abs(tzoffset);
+	const op		  = tzoffset > 0 ? '-' : '+'; // TimezoneOffset is set as subtraction from localtime to UTC,
+                                                  //    on the other hand time in CLF is shown as subtraction from UTC to localtime.
+	const hour = numberToString(Math.floor(abstzoffset / 60));
+	const min  = numberToString(abstzoffset % 60);
+	return `${op}${hour}${min}`;
 }
 
 module.exports = function (now = new Date()) {
@@ -35,13 +33,13 @@ module.exports = function (now = new Date()) {
 		'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
 	];
 
-	const day		= numberToString(now.getUTCDate());
-	const month		= MONTHS[now.getUTCMonth()];
-	const year		= now.getUTCFullYear();
+	const day		= numberToString(now.getDate());
+	const month		= MONTHS[now.getMonth()];
+	const year		= now.getFullYear();
 
-	const hours		= numberToString(now.getUTCHours());
-	const minutes	= numberToString(now.getUTCMinutes());
-	const seconds	= numberToString(now.getUTCSeconds());
+	const hours		= numberToString(now.getHours());
+	const minutes	= numberToString(now.getMinutes());
+	const seconds	= numberToString(now.getSeconds());
 
 	const offset	= getCLFOffset(now);
 


### PR DESCRIPTION
We are using pino-clf, and so using clf-date in it.

- https://github.com/pinojs/pino-toke/blob/cc25a33512d70ee9ab07acee326c778d29d22010/tokens.js#L3
- https://github.com/pinojs/pino-toke/blob/cc25a33512d70ee9ab07acee326c778d29d22010/tokens.js#L36-L42


By the way, the time outputted in the CLF format is expressed by the local time and the time offset from UTC time, but clf-date is expressed UTC time and the wrong time offset.

For example: When clf-date is executed in JST

```js
const clfDate = require('./out/main');

const date = new Date();

// Without clfDate
console.log(date.toISOString());
// console.log print 2018-04-15T07:48:23.191Z

// Without parameter it will use the current time.
console.log(clfDate(date));
// console.log print 15/Apr/2018:07:48:23 -0540

// With a Date in parameter.
date.setFullYear(2042);
console.log(clfDate(date));
// console.log print 15/Apr/2042:07:48:23 -0540
```

Because JST is UTC+09:00, the result of `clfDate(date)` should be `15/Apr/2018:16:48:23 +0900`.
ref. https://en.wikipedia.org/wiki/ISO_8601

This PR correctly express in local time as ISO 8601 format.

Below is the test shell script and result.

```bash
#!/bin/bash

timezones=$(cat << EOF | sed -e "s/#.*//"
    US/Samoa          # UTC-11:00
    US/Hawaii         # UTC-10:00
    Pacific/Marquesas # UTC-09:30
    US/Alaska         # UTC-09:00
    Pacific/Pitcairn  # UTC-08:00
    Mexico/BajaSur    # UTC-07:00
    Pacific/Easter    # UTC-06:00
    Jamaica           # UTC-05:00
    UTC               # UTC-+00:00
    Poland            # UTC+01:00
    Iran              # UTC+03:30
    Asia/Tokyo        # UTC+09:00
    Pacific/Norfolk   # UTC+11:00
    Pacific/Nauru     # UTC+12:00
    Pacific/Chatham   # UTC+12:45
EOF
)

for TZ in ${timezones[@]}
do
    echo "-- test result in timezone ${TZ}"
    ln -sf "/usr/share/zoneinfo/${TZ}" "/etc/localtime"
    node test.js
done
```

```text
-- test result in timezone US/Samoa
2018-04-15T11:36:16.217Z
15/Apr/2018:00:36:16 -1100
15/Apr/2042:00:36:16 -1100
-- test result in timezone US/Hawaii
2018-04-15T11:36:16.286Z
15/Apr/2018:01:36:16 -1000
15/Apr/2042:01:36:16 -1000
-- test result in timezone Pacific/Marquesas
2018-04-15T11:36:16.353Z
15/Apr/2018:02:06:16 -0930
15/Apr/2042:02:06:16 -0930
-- test result in timezone US/Alaska
2018-04-15T11:36:16.419Z
15/Apr/2018:03:36:16 -0800
15/Apr/2042:03:36:16 -0800
-- test result in timezone Pacific/Pitcairn
2018-04-15T11:36:16.492Z
15/Apr/2018:03:36:16 -0800
15/Apr/2042:03:36:16 -0800
-- test result in timezone Mexico/BajaSur
2018-04-15T11:36:16.554Z
15/Apr/2018:05:36:16 -0600
15/Apr/2042:05:36:16 -0600
-- test result in timezone Pacific/Easter
2018-04-15T11:36:16.634Z
15/Apr/2018:06:36:16 -0500
15/Apr/2042:06:36:16 -0500
-- test result in timezone Jamaica
2018-04-15T11:36:16.728Z
15/Apr/2018:06:36:16 -0500
15/Apr/2042:06:36:16 -0500
-- test result in timezone UTC
2018-04-15T11:36:16.801Z
15/Apr/2018:11:36:16 +0000
15/Apr/2042:11:36:16 +0000
-- test result in timezone Poland
2018-04-15T11:36:16.862Z
15/Apr/2018:13:36:16 +0200
15/Apr/2042:13:36:16 +0200
-- test result in timezone Iran
2018-04-15T11:36:16.927Z
15/Apr/2018:16:06:16 +0430
15/Apr/2042:16:06:16 +0430
-- test result in timezone Asia/Tokyo
2018-04-15T11:36:17.003Z
15/Apr/2018:20:36:17 +0900
15/Apr/2042:20:36:17 +0900
-- test result in timezone Pacific/Norfolk
2018-04-15T11:36:17.065Z
15/Apr/2018:22:36:17 +1100
15/Apr/2042:22:36:17 +1100
-- test result in timezone Pacific/Nauru
2018-04-15T11:36:17.128Z
15/Apr/2018:23:36:17 +1200
15/Apr/2042:23:36:17 +1200
-- test result in timezone Pacific/Chatham
2018-04-15T11:36:17.191Z
16/Apr/2018:00:21:17 +1245
16/Apr/2042:00:21:17 +1245
```
ref. https://en.wikipedia.org/wiki/List_of_UTC_time_offsets#UTC%C2%B100:00,_Z

I'd appreciate it if you decide to merge to master branch.

regards.